### PR TITLE
[#1] 로그인 구현

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,4 @@
+FROM openjdk:21-jdk-slim
+COPY build/libs/user-0.0.1-SNAPSHOT.jar owner.jar
+ENV TZ=Asia/Seoul
+ENTRYPOINT ["java", "-jar", "owner.jar"]

--- a/build.gradle
+++ b/build.gradle
@@ -18,6 +18,25 @@ repositories {
 }
 
 dependencies {
+
+    // Lombok
+    compileOnly 'org.projectlombok:lombok:1.18.38'
+    annotationProcessor 'org.projectlombok:lombok:1.18.38'
+
+    // MapStruct
+    implementation 'org.mapstruct:mapstruct:1.6.3'
+    annotationProcessor 'org.mapstruct:mapstruct-processor:1.6.3'
+
+    // Swagger
+    implementation("org.springdoc:springdoc-openapi-starter-webmvc-ui:2.8.6")
+
+    // Postgresql
+    implementation("org.postgresql:postgresql:42.7.5")
+
+    // Jpa
+    implementation("org.springframework.boot:spring-boot-starter-data-jpa:3.4.4")
+
+    implementation 'org.springframework.boot:spring-boot-starter-web'
     implementation 'org.springframework.boot:spring-boot-starter'
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
     testRuntimeOnly 'org.junit.platform:junit-platform-launcher'

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,17 @@
+services:
+  postgres:
+    container_name: postgresql-owner
+    image: postgres:17.4
+    restart: always
+    volumes:
+      - postgres-data:/var/lib/postgresql/data
+    ports:
+      - "5432:5432"
+    environment:
+      POSTGRES_USER: owner
+      POSTGRES_PASSWORD: owner
+      POSTGRES_DB: owner
+
+volumes:
+  postgres-data:
+

--- a/src/main/java/com/baedal/owner/adapter/in/web/controller/OwnerController.java
+++ b/src/main/java/com/baedal/owner/adapter/in/web/controller/OwnerController.java
@@ -1,0 +1,30 @@
+package com.baedal.owner.adapter.in.web.controller;
+
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import com.baedal.owner.adapter.in.web.dto.command.LoginCommand;
+import com.baedal.owner.adapter.in.web.dto.request.LoginRequest;
+import com.baedal.owner.adapter.in.web.dto.response.LoginResponse;
+import com.baedal.owner.adapter.in.web.mapper.OwnerWebMapper;
+import com.baedal.owner.application.port.in.OwnerUseCase;
+
+import lombok.RequiredArgsConstructor;
+
+@RestController
+@RequestMapping("/owner")
+@RequiredArgsConstructor
+public class OwnerController {
+
+	private final OwnerWebMapper mapper;
+	private final OwnerUseCase ownerUseCase;
+
+	@PostMapping("/login")
+	public LoginResponse login(@RequestBody LoginRequest req) {
+		LoginCommand.Request command = mapper.loginToCommand(req);
+		LoginCommand.Response response = ownerUseCase.login(command);
+		return mapper.loginToResponse(response);
+	}
+}

--- a/src/main/java/com/baedal/owner/adapter/in/web/controller/OwnerController.java
+++ b/src/main/java/com/baedal/owner/adapter/in/web/controller/OwnerController.java
@@ -5,7 +5,7 @@ import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
-import com.baedal.owner.adapter.in.web.dto.command.LoginCommand;
+import com.baedal.owner.application.command.LoginCommand;
 import com.baedal.owner.adapter.in.web.dto.request.LoginRequest;
 import com.baedal.owner.adapter.in.web.dto.response.LoginResponse;
 import com.baedal.owner.adapter.in.web.mapper.OwnerWebMapper;

--- a/src/main/java/com/baedal/owner/adapter/in/web/dto/command/LoginCommand.java
+++ b/src/main/java/com/baedal/owner/adapter/in/web/dto/command/LoginCommand.java
@@ -1,0 +1,20 @@
+package com.baedal.owner.adapter.in.web.dto.command;
+
+import lombok.Builder;
+import lombok.Getter;
+
+public class LoginCommand {
+
+  @Getter
+  @Builder
+  public static class Request {
+    private String account;
+    private String password;
+  }
+
+  @Getter
+  @Builder
+  public static class Response {
+    private Long ownerId;
+  }
+}

--- a/src/main/java/com/baedal/owner/adapter/in/web/dto/request/LoginRequest.java
+++ b/src/main/java/com/baedal/owner/adapter/in/web/dto/request/LoginRequest.java
@@ -1,0 +1,13 @@
+package com.baedal.owner.adapter.in.web.dto.request;
+
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class LoginRequest {
+
+  private String account;
+  private String password;
+
+}

--- a/src/main/java/com/baedal/owner/adapter/in/web/dto/response/LoginResponse.java
+++ b/src/main/java/com/baedal/owner/adapter/in/web/dto/response/LoginResponse.java
@@ -1,0 +1,12 @@
+package com.baedal.owner.adapter.in.web.dto.response;
+
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class LoginResponse {
+
+  private Long ownerId;
+
+}

--- a/src/main/java/com/baedal/owner/adapter/in/web/mapper/OwnerWebMapper.java
+++ b/src/main/java/com/baedal/owner/adapter/in/web/mapper/OwnerWebMapper.java
@@ -1,0 +1,15 @@
+package com.baedal.owner.adapter.in.web.mapper;
+
+import org.mapstruct.Mapper;
+
+import com.baedal.owner.adapter.in.web.dto.command.LoginCommand;
+import com.baedal.owner.adapter.in.web.dto.request.LoginRequest;
+import com.baedal.owner.adapter.in.web.dto.response.LoginResponse;
+
+@Mapper(componentModel = "spring")
+public interface OwnerWebMapper {
+
+  // 로그인
+  LoginCommand.Request loginToCommand(LoginRequest loginRequest);
+  LoginResponse loginToResponse(LoginCommand.Response loginCommand);
+}

--- a/src/main/java/com/baedal/owner/adapter/in/web/mapper/OwnerWebMapper.java
+++ b/src/main/java/com/baedal/owner/adapter/in/web/mapper/OwnerWebMapper.java
@@ -2,7 +2,7 @@ package com.baedal.owner.adapter.in.web.mapper;
 
 import org.mapstruct.Mapper;
 
-import com.baedal.owner.adapter.in.web.dto.command.LoginCommand;
+import com.baedal.owner.application.command.LoginCommand;
 import com.baedal.owner.adapter.in.web.dto.request.LoginRequest;
 import com.baedal.owner.adapter.in.web.dto.response.LoginResponse;
 

--- a/src/main/java/com/baedal/owner/adapter/out/persistence/adapter/OwnerRepositoryAdapter.java
+++ b/src/main/java/com/baedal/owner/adapter/out/persistence/adapter/OwnerRepositoryAdapter.java
@@ -1,0 +1,26 @@
+package com.baedal.owner.adapter.out.persistence.adapter;
+
+import org.springframework.stereotype.Component;
+
+import com.baedal.owner.adapter.out.persistence.entity.OwnerEntity;
+import com.baedal.owner.adapter.out.persistence.manager.OwnerEntityReader;
+import com.baedal.owner.adapter.out.persistence.mapper.OwnerPersistenceMapper;
+import com.baedal.owner.application.port.out.OwnerRepositoryPort;
+import com.baedal.owner.domain.model.Owner;
+
+import lombok.RequiredArgsConstructor;
+
+@Component
+@RequiredArgsConstructor
+public class OwnerRepositoryAdapter implements OwnerRepositoryPort {
+
+	private final OwnerEntityReader ownerEntityReader;
+	private final OwnerPersistenceMapper mapper;
+
+	@Override
+	public Owner findActiveUserByAccountAndPassword(String account, String password) {
+		OwnerEntity entity = ownerEntityReader.findByAccountAndPassword(account, password);
+		return mapper.entityToDomain(entity);
+	}
+
+}

--- a/src/main/java/com/baedal/owner/adapter/out/persistence/entity/OwnerEntity.java
+++ b/src/main/java/com/baedal/owner/adapter/out/persistence/entity/OwnerEntity.java
@@ -1,0 +1,31 @@
+package com.baedal.owner.adapter.out.persistence.entity;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Getter
+@Table(name = "owners")
+@AllArgsConstructor(access = AccessLevel.PROTECTED)
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class OwnerEntity {
+
+	@Id
+	@GeneratedValue(strategy = GenerationType.IDENTITY)
+	private Long id;
+
+	@Column(nullable = false)
+	private String account;
+
+	@Column(nullable = false)
+	private String password;
+
+}

--- a/src/main/java/com/baedal/owner/adapter/out/persistence/manager/OwnerEntityReader.java
+++ b/src/main/java/com/baedal/owner/adapter/out/persistence/manager/OwnerEntityReader.java
@@ -1,0 +1,21 @@
+package com.baedal.owner.adapter.out.persistence.manager;
+
+import org.springframework.stereotype.Component;
+
+import com.baedal.owner.adapter.out.persistence.entity.OwnerEntity;
+import com.baedal.owner.adapter.out.persistence.repository.OwnerJpaRepository;
+
+import lombok.RequiredArgsConstructor;
+
+@Component
+@RequiredArgsConstructor
+public class OwnerEntityReader {
+
+	private final OwnerJpaRepository ownerJpaRepository;
+
+	public OwnerEntity findByAccountAndPassword(String account, String password) {
+		return ownerJpaRepository.findByAccountAndPassword(account, password)
+			.orElseThrow(RuntimeException::new);
+	}
+
+}

--- a/src/main/java/com/baedal/owner/adapter/out/persistence/mapper/OwnerPersistenceMapper.java
+++ b/src/main/java/com/baedal/owner/adapter/out/persistence/mapper/OwnerPersistenceMapper.java
@@ -1,0 +1,12 @@
+package com.baedal.owner.adapter.out.persistence.mapper;
+
+import org.mapstruct.Mapper;
+
+import com.baedal.owner.adapter.out.persistence.entity.OwnerEntity;
+import com.baedal.owner.domain.model.Owner;
+
+@Mapper(componentModel = "spring")
+public interface OwnerPersistenceMapper {
+
+	Owner entityToDomain(OwnerEntity ownerEntity);
+}

--- a/src/main/java/com/baedal/owner/adapter/out/persistence/repository/OwnerJpaRepository.java
+++ b/src/main/java/com/baedal/owner/adapter/out/persistence/repository/OwnerJpaRepository.java
@@ -1,0 +1,12 @@
+package com.baedal.owner.adapter.out.persistence.repository;
+
+import java.util.Optional;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import com.baedal.owner.adapter.out.persistence.entity.OwnerEntity;
+
+public interface OwnerJpaRepository extends JpaRepository<OwnerEntity, Long> {
+
+	Optional<OwnerEntity> findByAccountAndPassword(String account, String password);
+}

--- a/src/main/java/com/baedal/owner/application/command/LoginCommand.java
+++ b/src/main/java/com/baedal/owner/application/command/LoginCommand.java
@@ -1,4 +1,4 @@
-package com.baedal.owner.adapter.in.web.dto.command;
+package com.baedal.owner.application.command;
 
 import lombok.Builder;
 import lombok.Getter;

--- a/src/main/java/com/baedal/owner/application/mapper/OwnerApplicationMapper.java
+++ b/src/main/java/com/baedal/owner/application/mapper/OwnerApplicationMapper.java
@@ -1,0 +1,16 @@
+package com.baedal.owner.application.mapper;
+
+import org.mapstruct.Mapper;
+import org.mapstruct.Mapping;
+
+import com.baedal.owner.adapter.in.web.dto.command.LoginCommand;
+import com.baedal.owner.domain.model.Owner;
+
+@Mapper(componentModel = "spring")
+public interface OwnerApplicationMapper {
+
+  // 로그인
+  @Mapping(target = "ownerId", source = "id")
+  LoginCommand.Response toLoginResponse(Owner owner);
+
+}

--- a/src/main/java/com/baedal/owner/application/mapper/OwnerApplicationMapper.java
+++ b/src/main/java/com/baedal/owner/application/mapper/OwnerApplicationMapper.java
@@ -3,7 +3,7 @@ package com.baedal.owner.application.mapper;
 import org.mapstruct.Mapper;
 import org.mapstruct.Mapping;
 
-import com.baedal.owner.adapter.in.web.dto.command.LoginCommand;
+import com.baedal.owner.application.command.LoginCommand;
 import com.baedal.owner.domain.model.Owner;
 
 @Mapper(componentModel = "spring")

--- a/src/main/java/com/baedal/owner/application/port/in/OwnerUseCase.java
+++ b/src/main/java/com/baedal/owner/application/port/in/OwnerUseCase.java
@@ -1,6 +1,6 @@
 package com.baedal.owner.application.port.in;
 
-import com.baedal.owner.adapter.in.web.dto.command.LoginCommand;
+import com.baedal.owner.application.command.LoginCommand;
 
 public interface OwnerUseCase {
 	LoginCommand.Response login(LoginCommand.Request req);

--- a/src/main/java/com/baedal/owner/application/port/in/OwnerUseCase.java
+++ b/src/main/java/com/baedal/owner/application/port/in/OwnerUseCase.java
@@ -1,0 +1,7 @@
+package com.baedal.owner.application.port.in;
+
+import com.baedal.owner.adapter.in.web.dto.command.LoginCommand;
+
+public interface OwnerUseCase {
+	LoginCommand.Response login(LoginCommand.Request req);
+}

--- a/src/main/java/com/baedal/owner/application/port/out/OwnerRepositoryPort.java
+++ b/src/main/java/com/baedal/owner/application/port/out/OwnerRepositoryPort.java
@@ -1,0 +1,8 @@
+package com.baedal.owner.application.port.out;
+
+import com.baedal.owner.domain.model.Owner;
+
+public interface OwnerRepositoryPort {
+
+	Owner findActiveUserByAccountAndPassword(String account, String password);
+}

--- a/src/main/java/com/baedal/owner/application/service/OwnerService.java
+++ b/src/main/java/com/baedal/owner/application/service/OwnerService.java
@@ -1,6 +1,7 @@
 package com.baedal.owner.application.service;
 
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 import com.baedal.owner.application.command.LoginCommand;
 import com.baedal.owner.application.mapper.OwnerApplicationMapper;
@@ -18,6 +19,7 @@ public class OwnerService implements OwnerUseCase {
 	private final OwnerApplicationMapper mapper;
 
 	@Override
+	@Transactional(readOnly = true)
 	public LoginCommand.Response login(LoginCommand.Request req) {
 		Owner owner = repositoryPort.findActiveUserByAccountAndPassword(req.getAccount(), req.getPassword());
 		return mapper.toLoginResponse(owner);

--- a/src/main/java/com/baedal/owner/application/service/OwnerService.java
+++ b/src/main/java/com/baedal/owner/application/service/OwnerService.java
@@ -1,6 +1,6 @@
 package com.baedal.owner.application.service;
 
-import org.springframework.stereotype.Component;
+import org.springframework.stereotype.Service;
 
 import com.baedal.owner.application.command.LoginCommand;
 import com.baedal.owner.application.mapper.OwnerApplicationMapper;
@@ -11,7 +11,7 @@ import com.baedal.owner.domain.model.Owner;
 import lombok.RequiredArgsConstructor;
 
 @RequiredArgsConstructor
-@Component
+@Service
 public class OwnerService implements OwnerUseCase {
 
 	private final OwnerRepositoryPort repositoryPort;

--- a/src/main/java/com/baedal/owner/application/service/OwnerService.java
+++ b/src/main/java/com/baedal/owner/application/service/OwnerService.java
@@ -1,0 +1,25 @@
+package com.baedal.owner.application.service;
+
+import org.springframework.stereotype.Component;
+
+import com.baedal.owner.adapter.in.web.dto.command.LoginCommand;
+import com.baedal.owner.application.mapper.OwnerApplicationMapper;
+import com.baedal.owner.application.port.in.OwnerUseCase;
+import com.baedal.owner.application.port.out.OwnerRepositoryPort;
+import com.baedal.owner.domain.model.Owner;
+
+import lombok.RequiredArgsConstructor;
+
+@RequiredArgsConstructor
+@Component
+public class OwnerService implements OwnerUseCase {
+
+	private final OwnerRepositoryPort repositoryPort;
+	private final OwnerApplicationMapper mapper;
+
+	@Override
+	public LoginCommand.Response login(LoginCommand.Request req) {
+		Owner owner = repositoryPort.findActiveUserByAccountAndPassword(req.getAccount(), req.getPassword());
+		return mapper.toLoginResponse(owner);
+	}
+}

--- a/src/main/java/com/baedal/owner/application/service/OwnerService.java
+++ b/src/main/java/com/baedal/owner/application/service/OwnerService.java
@@ -2,7 +2,7 @@ package com.baedal.owner.application.service;
 
 import org.springframework.stereotype.Component;
 
-import com.baedal.owner.adapter.in.web.dto.command.LoginCommand;
+import com.baedal.owner.application.command.LoginCommand;
 import com.baedal.owner.application.mapper.OwnerApplicationMapper;
 import com.baedal.owner.application.port.in.OwnerUseCase;
 import com.baedal.owner.application.port.out.OwnerRepositoryPort;

--- a/src/main/java/com/baedal/owner/domain/model/Owner.java
+++ b/src/main/java/com/baedal/owner/domain/model/Owner.java
@@ -1,0 +1,12 @@
+package com.baedal.owner.domain.model;
+
+import lombok.Builder;
+import lombok.Getter;
+
+@Builder
+@Getter
+public class Owner {
+
+	private Long id;
+
+}

--- a/src/main/resources/application-local.yml
+++ b/src/main/resources/application-local.yml
@@ -1,0 +1,18 @@
+spring:
+  application:
+    name: owner
+
+  datasource:
+    url: jdbc:postgresql://localhost:5432/owner
+    username: owner
+    password: owner
+    driver-class-name: org.postgresql.Driver
+
+
+  jpa:
+    hibernate:
+      ddl-auto: update
+    properties:
+      hibernate:
+        show_sql: true
+        format_sql: true

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,1 +1,0 @@
-spring.application.name=owner

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -1,0 +1,5 @@
+spring:
+  application:
+    name: owner
+  profiles:
+    active: local


### PR DESCRIPTION
헥사고날 아키텍쳐를 적용해 로그인 구현하였습니다.

현재 엔티티에는 필요한 컬럼 (id,account,password) 만을 정의하였고 ERD 작성이 완료되는데로 수정할 예정입니다.

현재 DTO 는 Builder 패턴을 활용하여 작성하였습니다만, 이후 record 를 활용하는 것도 좋은 방법이 될 수 있을 것같습니다.

Persistence 의 adapter 에서 jpaRepository 를 참조해 활용하는 것이 아닌, reader 클래스를 거치도록 설계하였습니다.
Reader 클래스는 jpaRepository 에서 반환 받은 Optional 객체를 꺼내고 예외 처리하는 역할을 담당하고 있습니다.
때문에 이후로도 adapter 은 repository 를 참조하지 않도록 주의가 필요할 것같습니다.

현재 RuntimeException 를 활용해 예외 처리를 진행하도록 되어있습니다. 이후 Exception 관련 논의 진행 이후 수정 예정입니다.