### PR TITLE
[#3] 매장 추가 구현

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -39,6 +39,9 @@ dependencies {
     // Kafka
     implementation("org.springframework.kafka:spring-kafka:3.3.4")
 
+    // Jackson-Datatype-jsr310
+    implementation("com.fasterxml.jackson.datatype:jackson-datatype-jsr310:2.18.3")
+
     implementation 'org.springframework.boot:spring-boot-starter-web'
     implementation 'org.springframework.boot:spring-boot-starter'
     testImplementation 'org.springframework.boot:spring-boot-starter-test'

--- a/build.gradle
+++ b/build.gradle
@@ -36,6 +36,9 @@ dependencies {
     // Jpa
     implementation("org.springframework.boot:spring-boot-starter-data-jpa:3.4.4")
 
+    // Kafka
+    implementation("org.springframework.kafka:spring-kafka:3.3.4")
+
     implementation 'org.springframework.boot:spring-boot-starter-web'
     implementation 'org.springframework.boot:spring-boot-starter'
     testImplementation 'org.springframework.boot:spring-boot-starter-test'

--- a/kafka-docker-compose.yml
+++ b/kafka-docker-compose.yml
@@ -1,0 +1,125 @@
+version: '3.8'
+
+networks:
+  kafka_network:
+
+volumes:
+  Kafka00:
+    driver: local
+  Kafka01:
+    driver: local
+  Kafka02:
+    driver: local
+
+services:
+  Kafka-1:
+    image: bitnami/kafka:3.7.0
+    restart: unless-stopped
+    container_name: Kafka01
+    ports:
+      - '9092:9092' # 내부 네트워크 통신을 위한 PLAINTEXT 리스너
+      - '10000:10000' # 외부 접근을 위한 EXTERNAL 리스너
+    environment:
+      # KRaft 설정
+      - KAFKA_ENABLE_KRAFT=yes # KRaft 모드 활성화
+      - KAFKA_CFG_BROKER_ID=0
+      - KAFKA_CFG_NODE_ID=0
+      - KAFKA_KRAFT_CLUSTER_ID=HsDBs9l6UUmQq7Y5E6bNlw # 고유 클러스터 ID, 모든 브로커에 동일하게 설정
+      - KAFKA_CFG_CONTROLLER_QUORUM_VOTERS=0@Kafka-1:9093,1@Kafka-2:9093,2@Kafka-3:9093
+      - KAFKA_CFG_PROCESS_ROLES=controller,broker
+      # 리스너 설정
+      - KAFKA_CFG_AUTO_CREATE_TOPICS_ENABLE=true
+      - ALLOW_PLAINTEXT_LISTENER=yes
+      - KAFKA_CFG_LISTENERS=PLAINTEXT://:9092,CONTROLLER://:9093,EXTERNAL://:10000
+      - KAFKA_CFG_ADVERTISED_LISTENERS=PLAINTEXT://Kafka-1:9092,EXTERNAL://localhost:10000
+      - KAFKA_CFG_LISTENER_SECURITY_PROTOCOL_MAP=PLAINTEXT:PLAINTEXT,CONTROLLER:PLAINTEXT,EXTERNAL:PLAINTEXT
+      - KAFKA_CFG_CONTROLLER_LISTENER_NAMES=CONTROLLER
+      # 클러스터 설정
+      - KAFKA_CFG_OFFSETS_TOPIC_REPLICATION_FACTOR=2
+      - KAFKA_CFG_TRANSACTION_STATE_LOG_REPLICATION_FACTOR=2
+      - KAFKA_CFG_TRANSACTION_STATE_LOG_MIN_ISR=2
+    networks:
+      - kafka_network
+    volumes:
+      - Kafka00:/bitnami/kafka
+
+  Kafka-2:
+    image: bitnami/kafka:3.7.0
+    restart: unless-stopped
+    container_name: Kafka02
+    ports:
+      - '9093:9092' # 내부 네트워크 통신을 위한 PLAINTEXT 리스너
+      - '10001:10000' # 외부 접근을 위한 EXTERNAL 리스너
+    environment:
+      # KRaft 설정
+      - KAFKA_ENABLE_KRAFT=yes # KRaft 모드 활성화
+      - KAFKA_CFG_BROKER_ID=1
+      - KAFKA_CFG_NODE_ID=1
+      - KAFKA_KRAFT_CLUSTER_ID=HsDBs9l6UUmQq7Y5E6bNlw # 고유 클러스터 ID, 모든 브로커에 동일하게 설정
+      - KAFKA_CFG_CONTROLLER_QUORUM_VOTERS=0@Kafka-1:9093,1@Kafka-2:9093,2@Kafka-3:9093
+      - KAFKA_CFG_PROCESS_ROLES=controller,broker
+      # 리스너 설정
+      - KAFKA_CFG_AUTO_CREATE_TOPICS_ENABLE=true
+      - ALLOW_PLAINTEXT_LISTENER=yes
+      - KAFKA_CFG_LISTENERS=PLAINTEXT://:9092,CONTROLLER://:9093,EXTERNAL://:10000
+      - KAFKA_CFG_ADVERTISED_LISTENERS=PLAINTEXT://Kafka-2:9092,EXTERNAL://localhost:10001
+      - KAFKA_CFG_LISTENER_SECURITY_PROTOCOL_MAP=PLAINTEXT:PLAINTEXT,CONTROLLER:PLAINTEXT,EXTERNAL:PLAINTEXT
+      - KAFKA_CFG_CONTROLLER_LISTENER_NAMES=CONTROLLER
+      # 클러스터 설정
+      - KAFKA_CFG_OFFSETS_TOPIC_REPLICATION_FACTOR=2
+      - KAFKA_CFG_TRANSACTION_STATE_LOG_REPLICATION_FACTOR=2
+      - KAFKA_CFG_TRANSACTION_STATE_LOG_MIN_ISR=2
+    networks:
+      - kafka_network
+    volumes:
+      - Kafka01:/bitnami/kafka
+
+  Kafka-3:
+    image: bitnami/kafka:3.7.0
+    restart: unless-stopped
+    container_name: Kafka03
+    ports:
+      - '9094:9092' # 내부 네트워크 통신을 위한 PLAINTEXT 리스너
+      - '10002:10000' # 외부 접근을 위한 EXTERNAL 리스너
+    environment:
+      # KRaft 설정
+      - KAFKA_ENABLE_KRAFT=yes # KRaft 모드 활성화
+      - KAFKA_CFG_BROKER_ID=2
+      - KAFKA_CFG_NODE_ID=2
+      - KAFKA_KRAFT_CLUSTER_ID=HsDBs9l6UUmQq7Y5E6bNlw # 고유 클러스터 ID, 모든 브로커에 동일하게 설정
+      - KAFKA_CFG_CONTROLLER_QUORUM_VOTERS=0@Kafka-1:9093,1@Kafka-2:9093,2@Kafka-3:9093
+      - KAFKA_CFG_PROCESS_ROLES=controller,broker
+      # 리스너 설정
+      - KAFKA_CFG_AUTO_CREATE_TOPICS_ENABLE=true
+      - ALLOW_PLAINTEXT_LISTENER=yes
+      - KAFKA_CFG_LISTENERS=PLAINTEXT://:9092,CONTROLLER://:9093,EXTERNAL://:10000
+      - KAFKA_CFG_ADVERTISED_LISTENERS=PLAINTEXT://Kafka-3:9092,EXTERNAL://localhost:10002
+      - KAFKA_CFG_LISTENER_SECURITY_PROTOCOL_MAP=PLAINTEXT:PLAINTEXT,CONTROLLER:PLAINTEXT,EXTERNAL:PLAINTEXT
+      - KAFKA_CFG_CONTROLLER_LISTENER_NAMES=CONTROLLER
+      # 클러스터 설정
+      - KAFKA_CFG_OFFSETS_TOPIC_REPLICATION_FACTOR=2
+      - KAFKA_CFG_TRANSACTION_STATE_LOG_REPLICATION_FACTOR=2
+      - KAFKA_CFG_TRANSACTION_STATE_LOG_MIN_ISR=2
+    networks:
+      - kafka_network
+    volumes:
+      - Kafka02:/bitnami/kafka
+
+  KafkaWebUiService:
+    image: provectuslabs/kafka-ui:latest
+    restart: unless-stopped
+    container_name: KafkaWebUiContainer
+    ports:
+      - '8085:8080'
+    environment:
+      - KAFKA_CLUSTERS_0_NAME=Local-Kraft-Cluster
+      - KAFKA_CLUSTERS_0_BOOTSTRAPSERVERS=Kafka-1:9092,Kafka-2:9092,Kafka-3:9092
+      - DYNAMIC_CONFIG_ENABLED=true
+      - KAFKA_CLUSTERS_0_AUDIT_TOPICAUDITENABLED=true
+      - KAFKA_CLUSTERS_0_AUDIT_CONSOLEAUDITENABLED=true
+    depends_on:
+      - Kafka-1
+      - Kafka-2
+      - Kafka-3
+    networks:
+      - kafka_network

--- a/src/main/java/com/baedal/owner/OwnerApplication.java
+++ b/src/main/java/com/baedal/owner/OwnerApplication.java
@@ -6,8 +6,8 @@ import org.springframework.boot.autoconfigure.SpringBootApplication;
 @SpringBootApplication
 public class OwnerApplication {
 
-	public static void main(String[] args) {
-		SpringApplication.run(OwnerApplication.class, args);
-	}
+  public static void main(String[] args) {
+    SpringApplication.run(OwnerApplication.class, args);
+  }
 
 }

--- a/src/main/java/com/baedal/owner/adapter/in/web/controller/OwnerController.java
+++ b/src/main/java/com/baedal/owner/adapter/in/web/controller/OwnerController.java
@@ -20,21 +20,21 @@ import lombok.RequiredArgsConstructor;
 @RequiredArgsConstructor
 public class OwnerController {
 
-	private final OwnerWebMapper mapper;
-	private final OwnerUseCase ownerUseCase;
+  private final OwnerWebMapper mapper;
+  private final OwnerUseCase ownerUseCase;
 
-	@PostMapping("/login")
-	public LoginResponse login(@RequestBody LoginRequest req) {
-		LoginCommand.Request command = mapper.loginToCommand(req);
-		LoginCommand.Response response = ownerUseCase.login(command);
-		return mapper.loginToResponse(response);
-	}
+  @PostMapping("/login")
+  public LoginResponse login(@RequestBody LoginRequest req) {
+    LoginCommand.Request command = mapper.loginToCommand(req);
+    LoginCommand.Response response = ownerUseCase.login(command);
+    return mapper.loginToResponse(response);
+  }
 
-	@PostMapping("/addStore")
-	public void addStore(@RequestBody AddStoreRequest req) {
-		AddStoreCommand.Request command = mapper.addStoreToCommand(req);
-		// note. 인증 관련 코드 작성 이후 변경 예정
-		Long ownerId = 1L;
-		ownerUseCase.addStore(ownerId, command);
-	}
+  @PostMapping("/addStore")
+  public void addStore(@RequestBody AddStoreRequest req) {
+    AddStoreCommand.Request command = mapper.addStoreToCommand(req);
+    // note. 인증 관련 코드 작성 이후 변경 예정
+    Long ownerId = 1L;
+    ownerUseCase.addStore(ownerId, command);
+  }
 }

--- a/src/main/java/com/baedal/owner/adapter/in/web/controller/OwnerController.java
+++ b/src/main/java/com/baedal/owner/adapter/in/web/controller/OwnerController.java
@@ -5,6 +5,8 @@ import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
+import com.baedal.owner.adapter.in.web.dto.request.AddStoreRequest;
+import com.baedal.owner.application.command.AddStoreCommand;
 import com.baedal.owner.application.command.LoginCommand;
 import com.baedal.owner.adapter.in.web.dto.request.LoginRequest;
 import com.baedal.owner.adapter.in.web.dto.response.LoginResponse;
@@ -26,5 +28,13 @@ public class OwnerController {
 		LoginCommand.Request command = mapper.loginToCommand(req);
 		LoginCommand.Response response = ownerUseCase.login(command);
 		return mapper.loginToResponse(response);
+	}
+
+	@PostMapping("/addStore")
+	public void addStore(@RequestBody AddStoreRequest req) {
+		AddStoreCommand.Request command = mapper.addStoreToCommand(req);
+		// note. 인증 관련 코드 작성 이후 변경 예정
+		Long ownerId = 1L;
+		ownerUseCase.addStore(ownerId, command);
 	}
 }

--- a/src/main/java/com/baedal/owner/adapter/in/web/dto/request/AddStoreRequest.java
+++ b/src/main/java/com/baedal/owner/adapter/in/web/dto/request/AddStoreRequest.java
@@ -2,6 +2,8 @@ package com.baedal.owner.adapter.in.web.dto.request;
 
 import java.time.LocalDateTime;
 
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotBlank;
 import lombok.Builder;
 import lombok.Getter;
 
@@ -9,10 +11,32 @@ import lombok.Getter;
 @Builder
 public class AddStoreRequest {
 
+	@Schema(description = "매장명")
+	@NotBlank
 	private String name;
+
+	@Schema(description = "매장 부제목")
+	private String title;
+
+	@Schema(description = "매장 설명")
+	private String content;
+
+	@Schema(description = "매장 주소")
+	@NotBlank
 	private String address;
+
+	@Schema(description = "매장 사진")
 	private String pictureUrl;
+
+	@Schema(description = "카테고리")
+	private String category;
+
+	@Schema(description = "영업 시작 시간")
+	@NotBlank
 	private LocalDateTime openTime;
+
+	@Schema(description = "영업 종료 시간")
+	@NotBlank
 	private LocalDateTime closeTime;
 
 }

--- a/src/main/java/com/baedal/owner/adapter/in/web/dto/request/AddStoreRequest.java
+++ b/src/main/java/com/baedal/owner/adapter/in/web/dto/request/AddStoreRequest.java
@@ -1,0 +1,18 @@
+package com.baedal.owner.adapter.in.web.dto.request;
+
+import java.time.LocalDateTime;
+
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class AddStoreRequest {
+
+	private String name;
+	private String address;
+	private String pictureUrl;
+	private LocalDateTime openTime;
+	private LocalDateTime closeTime;
+
+}

--- a/src/main/java/com/baedal/owner/adapter/in/web/dto/request/AddStoreRequest.java
+++ b/src/main/java/com/baedal/owner/adapter/in/web/dto/request/AddStoreRequest.java
@@ -10,32 +10,32 @@ import lombok.Getter;
 @Builder
 public class AddStoreRequest {
 
-	@Schema(description = "매장명")
-	@NotBlank
-	private String name;
+  @Schema(description = "매장명")
+  @NotBlank
+  private String name;
 
-	@Schema(description = "매장 부제목")
-	private String title;
+  @Schema(description = "매장 부제목")
+  private String title;
 
-	@Schema(description = "매장 설명")
-	private String content;
+  @Schema(description = "매장 설명")
+  private String content;
 
-	@Schema(description = "매장 주소")
-	@NotBlank
-	private String address;
+  @Schema(description = "매장 주소")
+  @NotBlank
+  private String address;
 
-	@Schema(description = "매장 사진")
-	private String pictureUrl;
+  @Schema(description = "매장 사진")
+  private String pictureUrl;
 
-	@Schema(description = "카테고리")
-	private String category;
+  @Schema(description = "카테고리")
+  private String category;
 
-	@Schema(description = "영업 시작 시간")
-	@NotBlank
-	private LocalTime openTime;
+  @Schema(description = "영업 시작 시간")
+  @NotBlank
+  private LocalTime openTime;
 
-	@Schema(description = "영업 종료 시간")
-	@NotBlank
-	private LocalTime closeTime;
+  @Schema(description = "영업 종료 시간")
+  @NotBlank
+  private LocalTime closeTime;
 
 }

--- a/src/main/java/com/baedal/owner/adapter/in/web/dto/request/AddStoreRequest.java
+++ b/src/main/java/com/baedal/owner/adapter/in/web/dto/request/AddStoreRequest.java
@@ -1,9 +1,8 @@
 package com.baedal.owner.adapter.in.web.dto.request;
 
-import java.time.LocalDateTime;
-
 import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotBlank;
+import java.time.LocalTime;
 import lombok.Builder;
 import lombok.Getter;
 
@@ -33,10 +32,10 @@ public class AddStoreRequest {
 
 	@Schema(description = "영업 시작 시간")
 	@NotBlank
-	private LocalDateTime openTime;
+	private LocalTime openTime;
 
 	@Schema(description = "영업 종료 시간")
 	@NotBlank
-	private LocalDateTime closeTime;
+	private LocalTime closeTime;
 
 }

--- a/src/main/java/com/baedal/owner/adapter/in/web/mapper/OwnerWebMapper.java
+++ b/src/main/java/com/baedal/owner/adapter/in/web/mapper/OwnerWebMapper.java
@@ -2,6 +2,8 @@ package com.baedal.owner.adapter.in.web.mapper;
 
 import org.mapstruct.Mapper;
 
+import com.baedal.owner.adapter.in.web.dto.request.AddStoreRequest;
+import com.baedal.owner.application.command.AddStoreCommand;
 import com.baedal.owner.application.command.LoginCommand;
 import com.baedal.owner.adapter.in.web.dto.request.LoginRequest;
 import com.baedal.owner.adapter.in.web.dto.response.LoginResponse;
@@ -12,4 +14,7 @@ public interface OwnerWebMapper {
   // 로그인
   LoginCommand.Request loginToCommand(LoginRequest loginRequest);
   LoginResponse loginToResponse(LoginCommand.Response loginCommand);
+
+  // 매장 추가
+  AddStoreCommand.Request addStoreToCommand(AddStoreRequest addStoreRequest);
 }

--- a/src/main/java/com/baedal/owner/adapter/out/messaging/KafkaSender.java
+++ b/src/main/java/com/baedal/owner/adapter/out/messaging/KafkaSender.java
@@ -11,11 +11,11 @@ import lombok.RequiredArgsConstructor;
 @RequiredArgsConstructor
 public class KafkaSender {
 
-	private final KafkaTemplate<String, String> kafkaTemplate;
+  private final KafkaTemplate<String, String> kafkaTemplate;
 
-	public void sendMessage(String topic, String key, Object message) {
-		String json = ObjectMapperUtil.toJson(message);
-		kafkaTemplate.send(topic, key, json);
-	}
+  public void sendMessage(String topic, String key, Object message) {
+    String json = ObjectMapperUtil.toJson(message);
+    kafkaTemplate.send(topic, key, json);
+  }
 
 }

--- a/src/main/java/com/baedal/owner/adapter/out/messaging/KafkaSender.java
+++ b/src/main/java/com/baedal/owner/adapter/out/messaging/KafkaSender.java
@@ -3,16 +3,19 @@ package com.baedal.owner.adapter.out.messaging;
 import org.springframework.kafka.core.KafkaTemplate;
 import org.springframework.stereotype.Component;
 
+import com.baedal.owner.util.ObjectMapperUtil;
+
 import lombok.RequiredArgsConstructor;
 
 @Component
 @RequiredArgsConstructor
 public class KafkaSender {
 
-	private final KafkaTemplate<String, Object> kafkaTemplate;
+	private final KafkaTemplate<String, String> kafkaTemplate;
 
 	public void sendMessage(String topic, String key, Object message) {
-		kafkaTemplate.send(topic, key, message);
+		String json = ObjectMapperUtil.toJson(message);
+		kafkaTemplate.send(topic, key, json);
 	}
 
 }

--- a/src/main/java/com/baedal/owner/adapter/out/messaging/KafkaSender.java
+++ b/src/main/java/com/baedal/owner/adapter/out/messaging/KafkaSender.java
@@ -1,0 +1,18 @@
+package com.baedal.owner.adapter.out.messaging;
+
+import org.springframework.kafka.core.KafkaTemplate;
+import org.springframework.stereotype.Component;
+
+import lombok.RequiredArgsConstructor;
+
+@Component
+@RequiredArgsConstructor
+public class KafkaSender {
+
+	private final KafkaTemplate<String, Object> kafkaTemplate;
+
+	public void sendMessage(String topic, String key, Object message) {
+		kafkaTemplate.send(topic, key, message);
+	}
+
+}

--- a/src/main/java/com/baedal/owner/adapter/out/messaging/MessageSenderAdapter.java
+++ b/src/main/java/com/baedal/owner/adapter/out/messaging/MessageSenderAdapter.java
@@ -1,0 +1,21 @@
+package com.baedal.owner.adapter.out.messaging;
+
+import org.springframework.stereotype.Component;
+
+import com.baedal.owner.application.command.AddStoreCommand;
+import com.baedal.owner.application.port.out.MessageSenderPort;
+
+import lombok.RequiredArgsConstructor;
+
+// note. 이후 Topic 은 SecretKey 로 관리, Key/Value 는 암호화 고려해보면 좋을 것같습니다.
+@Component
+@RequiredArgsConstructor
+public class MessageSenderAdapter implements MessageSenderPort {
+
+	private final KafkaSender kafkaSender;
+
+	@Override
+	public void sendAddStore(Long ownerId, AddStoreCommand.Request req) {
+		kafkaSender.sendMessage("store.addStore", ownerId.toString(), req);
+	}
+}

--- a/src/main/java/com/baedal/owner/adapter/out/messaging/MessageSenderAdapter.java
+++ b/src/main/java/com/baedal/owner/adapter/out/messaging/MessageSenderAdapter.java
@@ -12,10 +12,10 @@ import lombok.RequiredArgsConstructor;
 @RequiredArgsConstructor
 public class MessageSenderAdapter implements MessageSenderPort {
 
-	private final KafkaSender kafkaSender;
+  private final KafkaSender kafkaSender;
 
-	@Override
-	public void sendAddStore(Long ownerId, AddStoreCommand.Request req) {
-		kafkaSender.sendMessage("store.addStore", ownerId.toString(), req);
-	}
+  @Override
+  public void sendAddStore(Long ownerId, AddStoreCommand.Request req) {
+    kafkaSender.sendMessage("store.addStore", ownerId.toString(), req);
+  }
 }

--- a/src/main/java/com/baedal/owner/adapter/out/persistence/adapter/OwnerRepositoryAdapter.java
+++ b/src/main/java/com/baedal/owner/adapter/out/persistence/adapter/OwnerRepositoryAdapter.java
@@ -14,19 +14,19 @@ import lombok.RequiredArgsConstructor;
 @RequiredArgsConstructor
 public class OwnerRepositoryAdapter implements OwnerRepositoryPort {
 
-	private final OwnerEntityReader ownerEntityReader;
-	private final OwnerPersistenceMapper mapper;
+  private final OwnerEntityReader ownerEntityReader;
+  private final OwnerPersistenceMapper mapper;
 
-	@Override
-	public Owner findActiveUserByAccountAndPassword(String account, String password) {
-		OwnerEntity entity = ownerEntityReader.findByAccountAndPassword(account, password);
-		return mapper.entityToDomain(entity);
-	}
+  @Override
+  public Owner findActiveUserByAccountAndPassword(String account, String password) {
+    OwnerEntity entity = ownerEntityReader.findByAccountAndPassword(account, password);
+    return mapper.entityToDomain(entity);
+  }
 
-	@Override
-	public Owner findById(Long id) {
-		OwnerEntity entity = ownerEntityReader.findById(id);
-		return mapper.entityToDomain(entity);
-	}
+  @Override
+  public Owner findById(Long id) {
+    OwnerEntity entity = ownerEntityReader.findById(id);
+    return mapper.entityToDomain(entity);
+  }
 
 }

--- a/src/main/java/com/baedal/owner/adapter/out/persistence/adapter/OwnerRepositoryAdapter.java
+++ b/src/main/java/com/baedal/owner/adapter/out/persistence/adapter/OwnerRepositoryAdapter.java
@@ -23,4 +23,10 @@ public class OwnerRepositoryAdapter implements OwnerRepositoryPort {
 		return mapper.entityToDomain(entity);
 	}
 
+	@Override
+	public Owner findById(Long id) {
+		OwnerEntity entity = ownerEntityReader.findById(id);
+		return mapper.entityToDomain(entity);
+	}
+
 }

--- a/src/main/java/com/baedal/owner/adapter/out/persistence/entity/OwnerEntity.java
+++ b/src/main/java/com/baedal/owner/adapter/out/persistence/entity/OwnerEntity.java
@@ -18,14 +18,14 @@ import lombok.NoArgsConstructor;
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class OwnerEntity {
 
-	@Id
-	@GeneratedValue(strategy = GenerationType.IDENTITY)
-	private Long id;
+  @Id
+  @GeneratedValue(strategy = GenerationType.IDENTITY)
+  private Long id;
 
-	@Column(nullable = false)
-	private String account;
+  @Column(nullable = false)
+  private String account;
 
-	@Column(nullable = false)
-	private String password;
+  @Column(nullable = false)
+  private String password;
 
 }

--- a/src/main/java/com/baedal/owner/adapter/out/persistence/manager/OwnerEntityReader.java
+++ b/src/main/java/com/baedal/owner/adapter/out/persistence/manager/OwnerEntityReader.java
@@ -15,7 +15,11 @@ public class OwnerEntityReader {
 
 	public OwnerEntity findByAccountAndPassword(String account, String password) {
 		return ownerJpaRepository.findByAccountAndPassword(account, password)
-			.orElseThrow(RuntimeException::new);
+				.orElseThrow(() -> new RuntimeException("잘못된 아이디/비밀번호 입니다."));
 	}
 
+	public OwnerEntity findById(Long id) {
+		return ownerJpaRepository.findById(id)
+				.orElseThrow(() -> new RuntimeException("존재하지 않거나 접근 권한이 없는 점주입니다."));
+	}
 }

--- a/src/main/java/com/baedal/owner/adapter/out/persistence/manager/OwnerEntityReader.java
+++ b/src/main/java/com/baedal/owner/adapter/out/persistence/manager/OwnerEntityReader.java
@@ -11,15 +11,15 @@ import lombok.RequiredArgsConstructor;
 @RequiredArgsConstructor
 public class OwnerEntityReader {
 
-	private final OwnerJpaRepository ownerJpaRepository;
+  private final OwnerJpaRepository ownerJpaRepository;
 
-	public OwnerEntity findByAccountAndPassword(String account, String password) {
-		return ownerJpaRepository.findByAccountAndPassword(account, password)
-				.orElseThrow(() -> new RuntimeException("잘못된 아이디/비밀번호 입니다."));
-	}
+  public OwnerEntity findByAccountAndPassword(String account, String password) {
+    return ownerJpaRepository.findByAccountAndPassword(account, password)
+        .orElseThrow(() -> new RuntimeException("잘못된 아이디/비밀번호 입니다."));
+  }
 
-	public OwnerEntity findById(Long id) {
-		return ownerJpaRepository.findById(id)
-				.orElseThrow(() -> new RuntimeException("존재하지 않거나 접근 권한이 없는 점주입니다."));
-	}
+  public OwnerEntity findById(Long id) {
+    return ownerJpaRepository.findById(id)
+        .orElseThrow(() -> new RuntimeException("존재하지 않거나 접근 권한이 없는 점주입니다."));
+  }
 }

--- a/src/main/java/com/baedal/owner/adapter/out/persistence/mapper/OwnerPersistenceMapper.java
+++ b/src/main/java/com/baedal/owner/adapter/out/persistence/mapper/OwnerPersistenceMapper.java
@@ -8,5 +8,5 @@ import com.baedal.owner.domain.model.Owner;
 @Mapper(componentModel = "spring")
 public interface OwnerPersistenceMapper {
 
-	Owner entityToDomain(OwnerEntity ownerEntity);
+  Owner entityToDomain(OwnerEntity ownerEntity);
 }

--- a/src/main/java/com/baedal/owner/adapter/out/persistence/repository/OwnerJpaRepository.java
+++ b/src/main/java/com/baedal/owner/adapter/out/persistence/repository/OwnerJpaRepository.java
@@ -8,5 +8,5 @@ import com.baedal.owner.adapter.out.persistence.entity.OwnerEntity;
 
 public interface OwnerJpaRepository extends JpaRepository<OwnerEntity, Long> {
 
-	Optional<OwnerEntity> findByAccountAndPassword(String account, String password);
+  Optional<OwnerEntity> findByAccountAndPassword(String account, String password);
 }

--- a/src/main/java/com/baedal/owner/application/command/AddStoreCommand.java
+++ b/src/main/java/com/baedal/owner/application/command/AddStoreCommand.java
@@ -1,7 +1,6 @@
 package com.baedal.owner.application.command;
 
-import java.time.LocalDateTime;
-
+import java.time.LocalTime;
 import lombok.Builder;
 import lombok.Getter;
 
@@ -13,8 +12,8 @@ public class AddStoreCommand {
     private String name;
     private String address;
     private String pictureUrl;
-    private LocalDateTime openTime;
-    private LocalDateTime closeTime;
+    private LocalTime openTime;
+    private LocalTime closeTime;
   }
 
 }

--- a/src/main/java/com/baedal/owner/application/command/AddStoreCommand.java
+++ b/src/main/java/com/baedal/owner/application/command/AddStoreCommand.java
@@ -9,6 +9,7 @@ public class AddStoreCommand {
   @Getter
   @Builder
   public static class Request {
+
     private String name;
     private String address;
     private String pictureUrl;

--- a/src/main/java/com/baedal/owner/application/command/AddStoreCommand.java
+++ b/src/main/java/com/baedal/owner/application/command/AddStoreCommand.java
@@ -1,0 +1,20 @@
+package com.baedal.owner.application.command;
+
+import java.time.LocalDateTime;
+
+import lombok.Builder;
+import lombok.Getter;
+
+public class AddStoreCommand {
+
+  @Getter
+  @Builder
+  public static class Request {
+    private String name;
+    private String address;
+    private String pictureUrl;
+    private LocalDateTime openTime;
+    private LocalDateTime closeTime;
+  }
+
+}

--- a/src/main/java/com/baedal/owner/application/command/LoginCommand.java
+++ b/src/main/java/com/baedal/owner/application/command/LoginCommand.java
@@ -8,6 +8,7 @@ public class LoginCommand {
   @Getter
   @Builder
   public static class Request {
+
     private String account;
     private String password;
   }
@@ -15,6 +16,7 @@ public class LoginCommand {
   @Getter
   @Builder
   public static class Response {
+
     private Long ownerId;
   }
 }

--- a/src/main/java/com/baedal/owner/application/port/in/OwnerUseCase.java
+++ b/src/main/java/com/baedal/owner/application/port/in/OwnerUseCase.java
@@ -1,7 +1,9 @@
 package com.baedal.owner.application.port.in;
 
+import com.baedal.owner.application.command.AddStoreCommand;
 import com.baedal.owner.application.command.LoginCommand;
 
 public interface OwnerUseCase {
 	LoginCommand.Response login(LoginCommand.Request req);
+	void addStore(Long ownerId, AddStoreCommand.Request req);
 }

--- a/src/main/java/com/baedal/owner/application/port/in/OwnerUseCase.java
+++ b/src/main/java/com/baedal/owner/application/port/in/OwnerUseCase.java
@@ -4,6 +4,8 @@ import com.baedal.owner.application.command.AddStoreCommand;
 import com.baedal.owner.application.command.LoginCommand;
 
 public interface OwnerUseCase {
-	LoginCommand.Response login(LoginCommand.Request req);
-	void addStore(Long ownerId, AddStoreCommand.Request req);
+
+  LoginCommand.Response login(LoginCommand.Request req);
+
+  void addStore(Long ownerId, AddStoreCommand.Request req);
 }

--- a/src/main/java/com/baedal/owner/application/port/out/MessageSenderPort.java
+++ b/src/main/java/com/baedal/owner/application/port/out/MessageSenderPort.java
@@ -3,5 +3,6 @@ package com.baedal.owner.application.port.out;
 import com.baedal.owner.application.command.AddStoreCommand;
 
 public interface MessageSenderPort {
-	void sendAddStore(Long ownerId, AddStoreCommand.Request req);
+
+  void sendAddStore(Long ownerId, AddStoreCommand.Request req);
 }

--- a/src/main/java/com/baedal/owner/application/port/out/MessageSenderPort.java
+++ b/src/main/java/com/baedal/owner/application/port/out/MessageSenderPort.java
@@ -1,0 +1,7 @@
+package com.baedal.owner.application.port.out;
+
+import com.baedal.owner.application.command.AddStoreCommand;
+
+public interface MessageSenderPort {
+	void sendAddStore(Long ownerId, AddStoreCommand.Request req);
+}

--- a/src/main/java/com/baedal/owner/application/port/out/OwnerRepositoryPort.java
+++ b/src/main/java/com/baedal/owner/application/port/out/OwnerRepositoryPort.java
@@ -4,6 +4,7 @@ import com.baedal.owner.domain.model.Owner;
 
 public interface OwnerRepositoryPort {
 
-	Owner findActiveUserByAccountAndPassword(String account, String password);
-	Owner findById(Long id);
+  Owner findActiveUserByAccountAndPassword(String account, String password);
+
+  Owner findById(Long id);
 }

--- a/src/main/java/com/baedal/owner/application/port/out/OwnerRepositoryPort.java
+++ b/src/main/java/com/baedal/owner/application/port/out/OwnerRepositoryPort.java
@@ -5,4 +5,5 @@ import com.baedal.owner.domain.model.Owner;
 public interface OwnerRepositoryPort {
 
 	Owner findActiveUserByAccountAndPassword(String account, String password);
+	Owner findById(Long id);
 }

--- a/src/main/java/com/baedal/owner/application/service/OwnerService.java
+++ b/src/main/java/com/baedal/owner/application/service/OwnerService.java
@@ -3,9 +3,11 @@ package com.baedal.owner.application.service;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import com.baedal.owner.application.command.AddStoreCommand;
 import com.baedal.owner.application.command.LoginCommand;
 import com.baedal.owner.application.mapper.OwnerApplicationMapper;
 import com.baedal.owner.application.port.in.OwnerUseCase;
+import com.baedal.owner.application.port.out.MessageSenderPort;
 import com.baedal.owner.application.port.out.OwnerRepositoryPort;
 import com.baedal.owner.domain.model.Owner;
 
@@ -17,11 +19,17 @@ public class OwnerService implements OwnerUseCase {
 
 	private final OwnerRepositoryPort repositoryPort;
 	private final OwnerApplicationMapper mapper;
+	private final MessageSenderPort messageSenderPort;
 
 	@Override
 	@Transactional(readOnly = true)
 	public LoginCommand.Response login(LoginCommand.Request req) {
 		Owner owner = repositoryPort.findActiveUserByAccountAndPassword(req.getAccount(), req.getPassword());
 		return mapper.toLoginResponse(owner);
+	}
+
+	@Override
+	public void addStore(Long ownerId, AddStoreCommand.Request req) {
+		messageSenderPort.sendAddStore(ownerId, req);
 	}
 }

--- a/src/main/java/com/baedal/owner/application/service/OwnerService.java
+++ b/src/main/java/com/baedal/owner/application/service/OwnerService.java
@@ -24,7 +24,9 @@ public class OwnerService implements OwnerUseCase {
 	@Override
 	@Transactional(readOnly = true)
 	public LoginCommand.Response login(LoginCommand.Request req) {
-		Owner owner = repositoryPort.findActiveUserByAccountAndPassword(req.getAccount(), req.getPassword());
+		Owner owner = repositoryPort.findActiveUserByAccountAndPassword(
+				req.getAccount(), req.getPassword()
+		);
 		return mapper.toLoginResponse(owner);
 	}
 

--- a/src/main/java/com/baedal/owner/application/service/OwnerService.java
+++ b/src/main/java/com/baedal/owner/application/service/OwnerService.java
@@ -29,7 +29,9 @@ public class OwnerService implements OwnerUseCase {
 	}
 
 	@Override
+	@Transactional(readOnly = true)
 	public void addStore(Long ownerId, AddStoreCommand.Request req) {
+		repositoryPort.findById(ownerId);
 		messageSenderPort.sendAddStore(ownerId, req);
 	}
 }

--- a/src/main/java/com/baedal/owner/config/KafkaConfig.java
+++ b/src/main/java/com/baedal/owner/config/KafkaConfig.java
@@ -16,25 +16,25 @@ import org.springframework.kafka.support.serializer.JsonSerializer;
 @Configuration
 public class KafkaConfig {
 
-	@Value("${spring.kafka.producer.bootstrap-servers}")
-	private String bootstrapServers;
+  @Value("${spring.kafka.producer.bootstrap-servers}")
+  private String bootstrapServers;
 
-	@Bean
-	public KafkaTemplate<String, String> kafkaTemplate() {
-		return new KafkaTemplate<>(producerFactory());
-	}
+  @Bean
+  public KafkaTemplate<String, String> kafkaTemplate() {
+    return new KafkaTemplate<>(producerFactory());
+  }
 
-	@Bean
-	public ProducerFactory<String, String> producerFactory() {
-		return new DefaultKafkaProducerFactory<>(producerConfigs());
-	}
+  @Bean
+  public ProducerFactory<String, String> producerFactory() {
+    return new DefaultKafkaProducerFactory<>(producerConfigs());
+  }
 
-	@Bean
-	public Map<String, Object> producerConfigs() {
-		Map<String, Object> configProps = new HashMap<>();
-		configProps.put(ProducerConfig.BOOTSTRAP_SERVERS_CONFIG, bootstrapServers);
-		configProps.put(ProducerConfig.KEY_SERIALIZER_CLASS_CONFIG, StringSerializer.class);
-		configProps.put(ProducerConfig.VALUE_SERIALIZER_CLASS_CONFIG, JsonSerializer.class);
-		return configProps;
-	}
+  @Bean
+  public Map<String, Object> producerConfigs() {
+    Map<String, Object> configProps = new HashMap<>();
+    configProps.put(ProducerConfig.BOOTSTRAP_SERVERS_CONFIG, bootstrapServers);
+    configProps.put(ProducerConfig.KEY_SERIALIZER_CLASS_CONFIG, StringSerializer.class);
+    configProps.put(ProducerConfig.VALUE_SERIALIZER_CLASS_CONFIG, JsonSerializer.class);
+    return configProps;
+  }
 }

--- a/src/main/java/com/baedal/owner/config/KafkaConfig.java
+++ b/src/main/java/com/baedal/owner/config/KafkaConfig.java
@@ -20,12 +20,12 @@ public class KafkaConfig {
 	private String bootstrapServers;
 
 	@Bean
-	public KafkaTemplate<String, Object> kafkaTemplate() {
+	public KafkaTemplate<String, String> kafkaTemplate() {
 		return new KafkaTemplate<>(producerFactory());
 	}
 
 	@Bean
-	public ProducerFactory<String, Object> producerFactory() {
+	public ProducerFactory<String, String> producerFactory() {
 		return new DefaultKafkaProducerFactory<>(producerConfigs());
 	}
 

--- a/src/main/java/com/baedal/owner/config/KafkaConfig.java
+++ b/src/main/java/com/baedal/owner/config/KafkaConfig.java
@@ -1,0 +1,40 @@
+package com.baedal.owner.config;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import org.apache.kafka.clients.producer.ProducerConfig;
+import org.apache.kafka.common.serialization.StringSerializer;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.kafka.core.DefaultKafkaProducerFactory;
+import org.springframework.kafka.core.KafkaTemplate;
+import org.springframework.kafka.core.ProducerFactory;
+import org.springframework.kafka.support.serializer.JsonSerializer;
+
+@Configuration
+public class KafkaConfig {
+
+	@Value("${spring.kafka.producer.bootstrap-servers}")
+	private String bootstrapServers;
+
+	@Bean
+	public KafkaTemplate<String, Object> kafkaTemplate() {
+		return new KafkaTemplate<>(producerFactory());
+	}
+
+	@Bean
+	public ProducerFactory<String, Object> producerFactory() {
+		return new DefaultKafkaProducerFactory<>(producerConfigs());
+	}
+
+	@Bean
+	public Map<String, Object> producerConfigs() {
+		Map<String, Object> configProps = new HashMap<>();
+		configProps.put(ProducerConfig.BOOTSTRAP_SERVERS_CONFIG, bootstrapServers);
+		configProps.put(ProducerConfig.KEY_SERIALIZER_CLASS_CONFIG, StringSerializer.class);
+		configProps.put(ProducerConfig.VALUE_SERIALIZER_CLASS_CONFIG, JsonSerializer.class);
+		return configProps;
+	}
+}

--- a/src/main/java/com/baedal/owner/domain/model/Owner.java
+++ b/src/main/java/com/baedal/owner/domain/model/Owner.java
@@ -7,6 +7,6 @@ import lombok.Getter;
 @Getter
 public class Owner {
 
-	private Long id;
+  private Long id;
 
 }

--- a/src/main/java/com/baedal/owner/util/ObjectMapperUtil.java
+++ b/src/main/java/com/baedal/owner/util/ObjectMapperUtil.java
@@ -1,0 +1,22 @@
+package com.baedal.owner.util;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
+
+public class ObjectMapperUtil {
+
+	private static final ObjectMapper mapper = new ObjectMapper();
+
+	static {
+		mapper.registerModule(new JavaTimeModule());
+	}
+
+	public static String toJson(Object obj) {
+		try {
+			return mapper.writeValueAsString(obj);
+		} catch (JsonProcessingException e) {
+			throw new RuntimeException(e);
+		}
+	}
+}

--- a/src/main/resources/application-local.yml
+++ b/src/main/resources/application-local.yml
@@ -16,3 +16,9 @@ spring:
       hibernate:
         show_sql: true
         format_sql: true
+
+  kafka:
+    consumer:
+      bootstrap-servers: localhost:10000
+    producer:
+      bootstrap-servers: localhost:10000


### PR DESCRIPTION
매장 추가 API 구현했습니다.

매장 도메인으로 요청을 위해 Kafka 를 활용해 Request Command 값을 메세지큐를 전송하는 방식으로 구현했습니다.
이를 위해 (Object 전송) 직렬화 코드를 작성하였습니다. ( StringSerializer/JsonSerializer)

이후 외부 시스템이 변경 되더라도 ( Kafka -> RabbitMQ ) 각 클래스에 미치는 영향을 최소화 하기 위해 MessageSenderPort의 구현체인 MessageSenderAdapter 와 실제 Kafka 에 메세지를 보내는 KafkaSender 클래스를 작성하였습니다.

현재는 Topic, Key, Value 모두 별도의 암호화 없이 코드가 작성 되었습니다.
이후 SecretKey 혹은 암호화 적용 과정을 고려해보면 좋을 것같습니다.

로컬 환경에서 테스트를 위해 Kafka Cluster 구축을 위한 kafka-docker-compose 파일을 추가하였습니다.

기존 kafka value 값을 Object 로 전송했으나, 브로커와 컨슈머 간 DTO classType 비일치 문제 및 이후 유연성을 고려해 Value 값을 Json 으로 변환 후 String 으로 전송하도록 변경하였습니다.

이러한 변환 작업은 ObjectMapper 라이브러리를 사용했습니다.
ObjectMapper 은 기본적으로 시간 값에 대한 변환을 지원하지 않아 jackson-datatype-jsr310 라이브러리를 추가했습니다.
이를 ObjectMapperUtil static 파일 내에서 적용해 사용하도록 하였습니다.
Bean으로 관리하는 방법 또한 있었습니다만, ObjectMapper 은 전역적으로 사용되는 만큼 영향도를 최소화 하기 위해 채택하지 않았습니다.


해당 작업에서 추가된 의존성은 아래와 같습니다
- spring-kafka:3.3.4
- implementation("com.fasterxml.jackson.datatype:jackson-datatype-jsr310:2.18.3")